### PR TITLE
Fix VS Code extension packaging by disabling web build

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -38,7 +38,7 @@
     "package": "vsce package",
     "publish": "vsce publish",
     "publish-pre-release": "vsce publish --pre-release",
-    "vscode:prepublish": "rimraf dist && npm run -S esbuild-base -- --minify && npm run -S esbuild-web -- --minify",
+    "vscode:prepublish": "rimraf dist && npm run -S esbuild-base -- --minify",
     "test": "npm run typecheck"
   },
   "devDependencies": {
@@ -64,7 +64,6 @@
     "vsce": "^2.7.0"
   },
   "main": "./dist/extension.js",
-  "browser": "./dist/web-extension.js",
   "activationEvents": [
     "onDebugResolve:sbpf",
     "onDebugDynamicConfigurations:sbpf",


### PR DESCRIPTION
This PR fixes the VS Code extension packaging issue by removing the incompatible web build configuration.

## Changes
- Remove web extension build from `vscode:prepublish` script
- Remove `browser` field from `package.json`
- Allows desktop-only extension to be packaged successfully with `vsce package`

## Problem Solved
The extension was failing to package because the web build was trying to use Node.js modules like `child_process` which aren't available in the browser environment. Since this is a debugger extension that needs to spawn external processes, it's intended for desktop use only.

## Testing
- ✅ Successfully packages with `vsce package --no-yarn`
- ✅ Generated `sbpf-debug-0.52.0.vsix` file
- ✅ Extension builds without errors